### PR TITLE
Feature/add news page

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -24,6 +24,7 @@ const ContentWrapper = styled.div`
 
 const Footer = styled.footer`
   margin-top: 2rem;
+  text-align: center;
 `
 
 const Layout = ({ children }) => (

--- a/src/pages/news/index.js
+++ b/src/pages/news/index.js
@@ -1,0 +1,64 @@
+import React from "react"
+import styled from "styled-components"
+import CardPreviews from "../../components/cardPreviews"
+import Layout from "../../components/layout"
+import SEO from "../../components/seo"
+
+const Header = styled.h1`
+  text-align: center;
+`
+
+const NewsPage = ({ data }) => {
+  const { allMarkdownRemark: postsData } = data
+
+  const posts = postsData.edges.map(e => {
+    let post = {}
+
+    for (let key in e.node.frontmatter) {
+      post[key] = e.node.frontmatter[key]
+    }
+
+    post["slug"] = e.node.fields.slug
+    post["excerpt"] = e.node.excerpt
+
+    return post
+  })
+
+  return (
+    <Layout>
+      <SEO title="News &amp; Info" />
+
+      <Header>News &amp; Info</Header>
+
+      <CardPreviews posts={posts} />
+    </Layout>
+  )
+}
+
+export default NewsPage
+
+export const pageQuery = graphql`
+  query LastestNewsPostsQuery {
+    allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
+      limit: 10
+      filter: { frontmatter: { templateKey: { eq: "news-post" } } }
+    ) {
+      edges {
+        node {
+          excerpt(pruneLength: 300)
+          frontmatter {
+            author
+            title
+            date
+            tags
+            featuredimage
+          }
+          fields {
+            slug
+          }
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
- Added a simple page at /news with a card preview that filters on the news-post template key. Currently it takesthe 10 most recent posts and doesn't have any pagination
- Center aligned the footer text