### PR TITLE
Tweaking previews to work

### DIFF
--- a/src/cms/preview-templates/defaultTemplate.preview.js
+++ b/src/cms/preview-templates/defaultTemplate.preview.js
@@ -8,9 +8,11 @@ const DefaultTemplatePreview = ({ entry, widgetFor }) => {
   const date = entry.getIn(["data", "date"])
   const body = widgetFor("body")
 
-  const first300Chars = body.props.value.substr(0, 300)
+  const first300Chars = body?.props?.value.substr(0, 300)
 
-  const excerpt = `${first300Chars}${first300Chars.length === 300 ? "..." : ""}`
+  const excerpt = first300Chars
+    ? `${first300Chars}${first300Chars.length === 300 ? "..." : ""}`
+    : ""
 
   const card = <Card title={title} date={date} excerpt={excerpt} />
 

--- a/src/cms/preview-templates/preview-template.js
+++ b/src/cms/preview-templates/preview-template.js
@@ -30,7 +30,7 @@ const DesktopView = styled.div`
 const MobileView = styled.div`
   max-height: 736px;
   min-height: 736px;
-  max-width: 414px;
+  width: 414px;
   overflow: auto;
   padding: 1rem 0 0 0;
   box-shadow: rgba(0, 0, 0, 0.25) 6px 8px 20px;


### PR DESCRIPTION
- Don't access null props in the default template
- Force 414px width on mobile rather than `min-width`